### PR TITLE
Add dark layout with Discord auth and product carousel

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,13 @@
+import NextAuth from 'next-auth'
+import DiscordProvider from 'next-auth/providers/discord'
+
+const handler = NextAuth({
+  providers: [
+    DiscordProvider({
+      clientId: process.env.DISCORD_CLIENT_ID!,
+      clientSecret: process.env.DISCORD_CLIENT_SECRET!,
+    }),
+  ],
+})
+
+export { handler as GET, handler as POST }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,22 @@
 import { Inter } from 'next/font/google'
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+import AuthProvider from '@/components/AuthProvider'
+
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata = { title: "Prince's Development" }
 
-export default function RootLayout({ children }) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={inter.className}>
-      <body>{children}</body>
+      <body className="bg-[#0b0b0f] text-gray-200">
+        <AuthProvider>
+          <Navbar />
+          {children}
+          <Footer />
+        </AuthProvider>
+      </body>
     </html>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,41 +1,39 @@
-export default function Hero() {
+import FeaturedCarousel from '@/components/FeaturedCarousel'
+
+export default function Home() {
   return (
-    <section className="relative min-h-screen flex items-center justify-center overflow-hidden bg-[#0b0b0f] text-white pt-24">
-      {/* Background gradient */}
-      <div className="absolute inset-0 bg-gradient-to-r from-[#1D1D1F] via-[#FF69B4]/10 to-[#1D1D1F] opacity-50 blur-3xl"></div>
-
-      <div className="container relative mx-auto px-4 text-center flex flex-col items-center justify-center gap-8">
-        {/* Heading */}
-        <h1 className="max-w-4xl text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight">
-          Crafting{" "}
-          <span className="bg-gradient-to-r from-[#1D1D1F] via-[#FF69B4] to-[#1D1D1F] dark:from-white dark:via-[#FF69B4] dark:to-white bg-clip-text text-transparent relative">
-            extraordinary
-          </span>{" "}
-          experiences
-        </h1>
-
-        {/* Subheading */}
-        <p className="text-lg md:text-xl text-[#A3A3A3] dark:text-[#868686] max-w-2xl mx-auto leading-relaxed font-light">
-          Transform your FiveM server with our meticulously crafted scripts. <br />
-          Designed for performance, built for excellence.
-        </p>
-
-        {/* Call to Action buttons */}
-        <div className="flex flex-col sm:flex-row gap-6 mt-6">
-          <a
-            href="/scripts"
-            className="px-6 py-3 bg-pink-500 hover:bg-pink-600 text-white rounded-xl font-semibold transition"
-          >
-            Explore Scripts
-          </a>
-          <a
-            href="/commissions"
-            className="px-6 py-3 border border-white/20 hover:border-pink-400 rounded-xl font-semibold transition"
-          >
-            Start a Project
-          </a>
+    <main>
+      <section className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#0b0b0f] pt-24 text-white">
+        <div className="absolute inset-0 bg-gradient-to-r from-[#1D1D1F] via-[#FF69B4]/10 to-[#1D1D1F] opacity-50 blur-3xl" />
+        <div className="container relative mx-auto flex flex-col items-center justify-center gap-8 px-4 text-center">
+          <p className="text-sm tracking-widest text-pink-400">DEVELOPMENT STUDIO</p>
+          <h1 className="max-w-4xl text-5xl font-bold tracking-tight md:text-6xl lg:text-7xl">
+            Crafting{' '}
+            <span className="bg-gradient-to-r from-[#1D1D1F] via-[#FF69B4] to-[#1D1D1F] bg-clip-text text-transparent">extraordinary</span>{' '}
+            experiences
+          </h1>
+          <p className="max-w-2xl text-lg font-light leading-relaxed text-[#A3A3A3] md:text-xl">
+            Transform your FiveM server with our meticulously crafted scripts.
+            <br />
+            Designed for performance, built for excellence.
+          </p>
+          <div className="mt-6 flex flex-col gap-6 sm:flex-row">
+            <a
+              href="/products"
+              className="rounded-xl bg-pink-500 px-6 py-3 font-semibold text-white transition hover:bg-pink-600"
+            >
+              Explore Scripts
+            </a>
+            <a
+              href="/commissions"
+              className="rounded-xl border border-white/20 px-6 py-3 font-semibold transition hover:border-pink-400"
+            >
+              Start a Project
+            </a>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
+      <FeaturedCarousel />
+    </main>
   )
 }

--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { SessionProvider } from 'next-auth/react'
+
+export default function AuthProvider({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>
+}

--- a/components/FeaturedCarousel.tsx
+++ b/components/FeaturedCarousel.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import Image from 'next/image'
+import { products } from '@/lib/products'
+
+export default function FeaturedCarousel() {
+  const [index, setIndex] = useState(0)
+
+  useEffect(() => {
+    const id = setInterval(() => setIndex((i) => (i + 1) % products.length), 10000)
+    return () => clearInterval(id)
+  }, [])
+
+  const prev = () => setIndex((i) => (i - 1 + products.length) % products.length)
+  const next = () => setIndex((i) => (i + 1) % products.length)
+
+  const product = products[index]
+
+  return (
+    <div className="relative mx-auto mt-16 w-full max-w-xl text-center">
+      <div className="relative h-64 w-full">
+        <Image src={product.image} alt={product.name} fill className="rounded-xl object-cover" />
+      </div>
+      <h3 className="mt-4 text-2xl font-semibold text-white">{product.name}</h3>
+      <p className="mt-2 text-gray-400">{product.description}</p>
+      <div className="mt-4 flex justify-center gap-4">
+        <button onClick={prev} aria-label="Previous" className="rounded bg-white/10 px-4 py-2 hover:bg-white/20">←</button>
+        <button onClick={next} aria-label="Next" className="rounded bg-white/10 px-4 py-2 hover:bg-white/20">→</button>
+      </div>
+    </div>
+  )
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,12 +1,41 @@
+import Link from 'next/link'
+import Image from 'next/image'
+
 export default function Footer() {
-    return (
-      <footer className="border-t">
-        <div className="mx-auto max-w-6xl px-6 py-10 text-sm text-gray-600">
-          <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-            <p>© {new Date().getFullYear()} Prince's Development. All rights reserved.</p>
-            <p className="text-gray-500">Built with Next.js & Stripe.</p>
-          </div>
+  return (
+    <footer className="border-t border-white/10 bg-[#0b0b0f] text-sm text-gray-400">
+      <div className="mx-auto grid max-w-6xl gap-8 px-6 py-12 md:grid-cols-4">
+        <div>
+          <Image src="/logo.svg" alt="Inkwell Studios" width={40} height={40} />
+          <h2 className="mt-4 text-xl font-semibold text-white">Inkwell Studios</h2>
+          <p className="mt-4">
+            Crafting extraordinary experiences that redefine what's possible in FiveM development.
+          </p>
         </div>
-      </footer>
-    )
-  }
+        <div>
+          <h3 className="font-semibold text-white">Products</h3>
+          <ul className="mt-4 space-y-2">
+            <li><Link href="/products" className="hover:text-white">Scripts</Link></li>
+            <li><Link href="/videos" className="hover:text-white">Videos</Link></li>
+            <li><Link href="/downloads" className="hover:text-white">Downloads</Link></li>
+          </ul>
+        </div>
+        <div>
+          <h3 className="font-semibold text-white">Support</h3>
+          <ul className="mt-4 space-y-2">
+            <li><a href="https://discord.gg/" target="_blank" rel="noopener noreferrer" className="hover:text-white">Discord</a></li>
+            <li><Link href="/help" className="hover:text-white">Help Center</Link></li>
+          </ul>
+        </div>
+        <div>
+          <h3 className="font-semibold text-white">Company</h3>
+          <ul className="mt-4 space-y-2">
+            <li><Link href="/about" className="hover:text-white">About</Link></li>
+            <li><Link href="/terms" className="hover:text-white">Terms</Link></li>
+            <li><Link href="/privacy" className="hover:text-white">Privacy</Link></li>
+          </ul>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -3,36 +3,72 @@
 import Link from 'next/link'
 import Image from 'next/image'
 import { useState } from 'react'
+import { useSession, signIn, signOut } from 'next-auth/react'
 
 export default function Navbar() {
   const [open, setOpen] = useState(false)
+  const { data: session } = useSession()
 
   return (
-    <header className="sticky top-0 z-50 border-b bg-white/80 backdrop-blur">
-      <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-6 py-3">
+    <header className="sticky top-0 z-50 border-b border-white/10 bg-[#0b0b0f]/80 backdrop-blur">
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-6 py-3 text-sm">
         <Link href="/" className="flex items-center gap-2">
-          <Image src="/logo.svg" alt="Prince's Development" width={28} height={28} />
-          <span className="text-lg font-semibold">Prince's Development</span>
+          <Image src="/logo.svg" alt="Inkwell Studios" width={32} height={32} />
         </Link>
-        <nav className="hidden items-center gap-6 text-sm md:flex">
-          <Link href="/products" className="hover:text-brand-700">Products</Link>
-          <Link href="/commissions" className="hover:text-brand-700">Commissions</Link>
-          <Link href="/videos" className="hover:text-brand-700">Videos</Link>
-          <Link href="/downloads" className="hover:text-brand-700">Downloads</Link>
-          <Link href="/about" className="hover:text-brand-700">About</Link>
+        <nav className="hidden items-center gap-6 md:flex">
+          <Link href="/products" className="hover:text-white">Store</Link>
+          <Link href="/commissions" className="hover:text-white">Commissions</Link>
+          <div className="relative group">
+            <button className="flex items-center gap-1 hover:text-white">Support ▾</button>
+            <div className="absolute left-1/2 top-full hidden w-40 -translate-x-1/2 rounded-md border border-white/10 bg-[#1d1d1f] text-sm group-hover:block">
+              <Link href="/faq" className="block px-4 py-2 hover:bg-white/5">FAQ</Link>
+              <Link href="/forums" className="block px-4 py-2 hover:bg-white/5">Forums</Link>
+              <Link href="/ticket" className="block px-4 py-2 hover:bg-white/5">Support Ticket</Link>
+            </div>
+          </div>
+          <div className="relative group">
+            <button className="flex items-center gap-1 hover:text-white">About ▾</button>
+            <div className="absolute left-1/2 top-full hidden w-40 -translate-x-1/2 rounded-md border border-white/10 bg-[#1d1d1f] text-sm group-hover:block">
+              <Link href="/about" className="block px-4 py-2 hover:bg-white/5">About Us</Link>
+              <a href="https://discord.gg/" className="block px-4 py-2 hover:bg-white/5" target="_blank" rel="noopener noreferrer">Discord</a>
+            </div>
+          </div>
         </nav>
-        <button className="md:hidden" onClick={() => setOpen(v => !v)} aria-label="Toggle Menu">
-          <span className="i">☰</span>
-        </button>
+        <div className="flex items-center gap-4">
+          <Link href="/cart" aria-label="Cart" className="hover:text-white">🛒</Link>
+          {session ? (
+            <button onClick={() => signOut()} className="flex items-center gap-2 hover:text-white">
+              {session.user?.image && (
+                <Image src={session.user.image} alt={session.user.name || ''} width={24} height={24} className="rounded-full" />
+              )}
+              <span>{session.user?.name}</span>
+            </button>
+          ) : (
+            <button onClick={() => signIn('discord')} className="rounded bg-pink-500 px-3 py-1 text-white hover:bg-pink-600">Sign In</button>
+          )}
+          <button className="md:hidden" onClick={() => setOpen(v => !v)} aria-label="Toggle Menu">☰</button>
+        </div>
       </div>
       {open && (
-        <div className="border-t md:hidden">
+        <div className="border-t border-white/10 bg-[#0b0b0f] md:hidden">
           <div className="mx-auto max-w-6xl px-6 py-3 space-y-2">
-            <Link href="/products" onClick={() => setOpen(false)} className="block">Products</Link>
+            <Link href="/products" onClick={() => setOpen(false)} className="block">Store</Link>
             <Link href="/commissions" onClick={() => setOpen(false)} className="block">Commissions</Link>
-            <Link href="/videos" onClick={() => setOpen(false)} className="block">Videos</Link>
-            <Link href="/downloads" onClick={() => setOpen(false)} className="block">Downloads</Link>
-            <Link href="/about" onClick={() => setOpen(false)} className="block">About</Link>
+            <div>
+              <span className="block">Support</span>
+              <div className="pl-4 space-y-1">
+                <Link href="/faq" onClick={() => setOpen(false)} className="block">FAQ</Link>
+                <Link href="/forums" onClick={() => setOpen(false)} className="block">Forums</Link>
+                <Link href="/ticket" onClick={() => setOpen(false)} className="block">Support Ticket</Link>
+              </div>
+            </div>
+            <div>
+              <span className="block">About</span>
+              <div className="pl-4 space-y-1">
+                <Link href="/about" onClick={() => setOpen(false)} className="block">About Us</Link>
+                <a href="https://discord.gg/" onClick={() => setOpen(false)} className="block" target="_blank" rel="noopener noreferrer">Discord</a>
+              </div>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- build site layout with navbar, footer, and session provider
- add Discord authentication route and sign-in button
- show featured product carousel on home page

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: interactive config prompt)


------
https://chatgpt.com/codex/tasks/task_e_68a0b3637a0883309855f11a2ec85089